### PR TITLE
feat: user-roles

### DIFF
--- a/src/main/java/com/ndungutse/project_tracker/controller/RoleController.java
+++ b/src/main/java/com/ndungutse/project_tracker/controller/RoleController.java
@@ -1,0 +1,117 @@
+package com.ndungutse.project_tracker.controller;
+
+import com.ndungutse.project_tracker.dto.RoleDTO;
+import com.ndungutse.project_tracker.service.RoleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/roles")
+@Tag(name = "Role", description = "Role management APIs")
+public class RoleController {
+
+    private final RoleService roleService;
+
+    public RoleController(RoleService roleService) {
+        this.roleService = roleService;
+    }
+
+    // Create a new role
+    @Operation(summary = "Create a new role", description = "Creates a new role with the provided name")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "Role created successfully",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = RoleDTO.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input data", content = @Content)
+    })
+    @PostMapping
+    public ResponseEntity<RoleDTO> createRole(
+            @Parameter(description = "Role data to create", required = true)
+            @RequestBody RoleDTO roleDTO) {
+        if (roleService.existsByName(roleDTO.getRoleName())) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+        RoleDTO createdRole = roleService.create(roleDTO);
+        return new ResponseEntity<>(createdRole, HttpStatus.CREATED);
+    }
+
+    // Get all roles
+    @Operation(summary = "Get all roles", description = "Returns a list of all roles")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved roles",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = RoleDTO.class)))
+    })
+    @GetMapping
+    public ResponseEntity<List<RoleDTO>> getAllRoles() {
+        List<RoleDTO> roles = roleService.getAll();
+        return new ResponseEntity<>(roles, HttpStatus.OK);
+    }
+
+    // Get a role by ID
+    @Operation(summary = "Get a role by ID", description = "Returns a role based on the provided ID")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved role",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = RoleDTO.class))),
+        @ApiResponse(responseCode = "404", description = "Role not found", content = @Content)
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<RoleDTO> getRoleById(
+            @Parameter(description = "ID of the role to retrieve", required = true)
+            @PathVariable Long id) {
+        Optional<RoleDTO> role = roleService.getById(id);
+        return role.map(value -> new ResponseEntity<>(value, HttpStatus.OK))
+                .orElseGet(() -> new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    // Update a role
+    @Operation(summary = "Update a role", description = "Updates a role with the provided details")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Role updated successfully",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = RoleDTO.class))),
+        @ApiResponse(responseCode = "404", description = "Role not found", content = @Content),
+        @ApiResponse(responseCode = "400", description = "Invalid input data", content = @Content)
+    })
+    @PatchMapping("/{id}")
+    public ResponseEntity<RoleDTO> updateRole(
+            @Parameter(description = "ID of the role to update", required = true)
+            @PathVariable Long id,
+            @Parameter(description = "Updated role data", required = true)
+            @RequestBody RoleDTO roleDTO
+    ) {
+        if (!roleService.exists(id)) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        Optional<RoleDTO> updatedRole = roleService.update(id, roleDTO);
+        return updatedRole.map(value -> new ResponseEntity<>(value, HttpStatus.OK))
+                .orElseGet(() -> new ResponseEntity<>(HttpStatus.BAD_REQUEST));
+    }
+
+    // Delete a role
+    @Operation(summary = "Delete a role", description = "Deletes a role based on the provided ID")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "Role deleted successfully", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Role not found", content = @Content)
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteRole(
+            @Parameter(description = "ID of the role to delete", required = true)
+            @PathVariable Long id) {
+        if (!roleService.exists(id)) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        roleService.delete(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/ndungutse/project_tracker/dto/RoleDTO.java
+++ b/src/main/java/com/ndungutse/project_tracker/dto/RoleDTO.java
@@ -1,0 +1,29 @@
+package com.ndungutse.project_tracker.dto;
+
+import com.ndungutse.project_tracker.model.Role;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoleDTO {
+    private Long id;
+    private String roleName;
+
+    // Convert Entity to DTO
+    public static RoleDTO fromEntity(Role role) {
+        return new RoleDTO(
+                role.getId(),
+                role.getRoleName());
+    }
+
+    // Convert DTO to Entity
+    public Role toEntity() {
+        return Role.builder()
+                .id(this.id)
+                .roleName(this.roleName)
+                .build();
+    }
+}

--- a/src/main/java/com/ndungutse/project_tracker/model/Role.java
+++ b/src/main/java/com/ndungutse/project_tracker/model/Role.java
@@ -1,0 +1,29 @@
+package com.ndungutse.project_tracker.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "roles")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Role {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String roleName;
+
+    @OneToMany(mappedBy = "role")
+    @Builder.Default
+    private List<User> users = new ArrayList<>();
+}

--- a/src/main/java/com/ndungutse/project_tracker/repository/RoleRepository.java
+++ b/src/main/java/com/ndungutse/project_tracker/repository/RoleRepository.java
@@ -1,0 +1,14 @@
+package com.ndungutse.project_tracker.repository;
+
+import com.ndungutse.project_tracker.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByRoleName(String roleName);
+
+    boolean existsByRoleName(String roleName);
+}

--- a/src/main/java/com/ndungutse/project_tracker/service/RoleService.java
+++ b/src/main/java/com/ndungutse/project_tracker/service/RoleService.java
@@ -1,0 +1,75 @@
+package com.ndungutse.project_tracker.service;
+
+import com.ndungutse.project_tracker.dto.RoleDTO;
+import com.ndungutse.project_tracker.model.Role;
+import com.ndungutse.project_tracker.repository.RoleRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class RoleService {
+    private final RoleRepository roleRepository;
+
+    public RoleService(RoleRepository roleRepository) {
+        this.roleRepository = roleRepository;
+    }
+
+    // Create
+    public RoleDTO create(RoleDTO roleDTO) {
+        Role role = roleDTO.toEntity();
+        Role savedRole = roleRepository.save(role);
+        return RoleDTO.fromEntity(savedRole);
+    }
+
+    // Read
+    public List<RoleDTO> getAll() {
+        List<Role> roles = roleRepository.findAll();
+        return roles.stream()
+                .map(RoleDTO::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public Optional<RoleDTO> getById(Long id) {
+        Optional<Role> role = roleRepository.findById(id);
+        return role.map(RoleDTO::fromEntity);
+    }
+
+    public Optional<RoleDTO> getByName(String roleName) {
+        Optional<Role> role = roleRepository.findByRoleName(roleName);
+        return role.map(RoleDTO::fromEntity);
+    }
+
+    // Update
+    @Transactional
+    public Optional<RoleDTO> update(Long id, RoleDTO updatedRoleDTO) {
+        Optional<Role> existingRole = roleRepository.findById(id);
+        if (existingRole.isPresent()) {
+            Role role = existingRole.get();
+
+            if (updatedRoleDTO.getRoleName() != null) {
+                role.setRoleName(updatedRoleDTO.getRoleName());
+            }
+
+            Role savedRole = roleRepository.save(role);
+            return Optional.of(RoleDTO.fromEntity(savedRole));
+        }
+        return Optional.empty();
+    }
+
+    // Delete
+    public void delete(Long id) {
+        roleRepository.deleteById(id);
+    }
+
+    public boolean exists(Long id) {
+        return roleRepository.existsById(id);
+    }
+
+    public boolean existsByName(String roleName) {
+        return roleRepository.existsByRoleName(roleName);
+    }
+}


### PR DESCRIPTION
## Description

This pull request introduces a comprehensive Role Management feature to the project. It includes the creation of a new `RoleController` for handling API requests, a `RoleService` for business logic, a `RoleRepository` for database operations, and associated `Role` and `RoleDTO` classes for entity and data transfer object management. The changes enable CRUD operations for roles, including validation and mapping between entities and DTOs.

### Role Management API Implementation:

* **`RoleController`**: Implements REST endpoints for creating, reading, updating, and deleting roles, with Swagger annotations for API documentation. Includes validation for unique role names and proper HTTP status codes for responses.

### Data Layer Enhancements:

* **`RoleRepository`**: Defines database operations for roles, including methods to check existence by name and retrieve roles by name.
* **`Role` Entity**: Represents the `roles` table in the database with fields for `id` and `roleName`. Includes a relationship with `User` entities and uses JPA annotations for persistence.

### Service Layer Logic:

* **`RoleService`**: Provides business logic for role operations, including conversion between `Role` entities and `RoleDTO`, validation, and transactional updates. Supports methods for CRUD operations and additional checks for role existence.

### DTO for Role:

* **`RoleDTO`**: Facilitates data transfer between layers, with methods to convert between `Role` entities and `RoleDTO` objects.